### PR TITLE
Remove page_restrictions option from page table

### DIFF
--- a/kwnlp_sql_parser/wp_sql_patterns.py
+++ b/kwnlp_sql_parser/wp_sql_patterns.py
@@ -357,7 +357,6 @@ _TABLE_COLUMN_PATTERNS = {
         WikipediaSqlColumn("page_id", DIGITS),
         WikipediaSqlColumn("page_namespace", DIGITS),
         WikipediaSqlColumn("page_title", ESCAPED_STRING, unquote=True, unescape=True),
-        WikipediaSqlColumn("page_restrictions", ESCAPED_STRING, unquote=True, unescape=True),
         WikipediaSqlColumn("page_is_redirect", DIGITS),
         WikipediaSqlColumn("page_is_new", DIGITS),
         WikipediaSqlColumn("page_random", FLOAT),


### PR DESCRIPTION
The `page_restrictions` key was removed from page table dumps in 1.39. The current version of the code builds a regex that won't parse current page table files because the page_restrictions key is missing. Here I removed `page_restrictions` so that the `WikipediaSqlDump` could successfully parse files of the format `*-page.sql.gz`.